### PR TITLE
Truncated Spaces

### DIFF
--- a/data/introduction.html
+++ b/data/introduction.html
@@ -39,11 +39,11 @@
             <p>&zwnj;<span name="distro-name"></span> is an operating system -- the core software
             that runs your computer, similar to&zwnj;
             <a onclick="cmd('link?http://www.microsoft.com')">
-            &nbsp;<span class="fa fa-windows"></span> &zwnj;Microsoft's Windows&zwnj;</a>,
+            <span class="fa fa-windows"></span>Microsoft's Windows&zwnj;</a>,
             <a onclick="cmd('link?http://www.apple.com')">
-            &nbsp;<span class="fa fa-apple"> </span> &zwnj;Apple's OS X&zwnj;</a> &zwnj;and&zwnj;
+            <span class="fa fa-apple"> </span>Apple's OS X&zwnj;</a> &zwnj;and&zwnj;
             <a onclick="cmd('link?http://www.google.com/chrome')">
-            &nbsp;<span class="fa fa-chrome"></span> &zwnj;Google's Chrome OS&zwnj;</a>.
+            <span class="fa fa-chrome"></span>Google's Chrome OS&zwnj;</a>.
 
             &zwnj;<span name="distro-name"></span> is a distribution (variation) of
             GNU/Linux. A dependable, secure, capable, and modern computer
@@ -54,7 +54,7 @@
                 supercomputers&zwnj;</li>
               <li>&zwnj;on many of (if not most of) the computers that make up the
                 backbone of Internet&zwnj;</li>
-              <li>&zwnj;and on corporate servers that require stability and
+              <li>&zwnj;on corporate servers that require stability and
                 reliability&zwnj;</li>
             </ul>
           </div>
@@ -183,9 +183,9 @@
               desktop environment using traditional metaphors, which
               means if you've ever used&zwnj;
               <a onclick="cmd('link?http://www.microsoft.com')">
-              &nbsp;<span class="fa fa-windows"></span> Windows</a> &zwnj;or&zwnj;
+              <span class="fa fa-windows"></span> Windows</a> &zwnj;or&zwnj;
               <a onclick="cmd('link?http://www.apple.com')">
-              &nbsp;<span class="fa fa-apple"> </span> OS X</a>,
+              <span class="fa fa-apple"></span> OS X</a>,
               &zwnj;it will feel very familiar.&zwnj;</p>
 
             </div>


### PR DESCRIPTION
By removing excess zero width non joiners that were placed before links to Windows, OSX, and ChromeOS references, I was able to truncate spaces. Also modified a bullet point to correct sentence suffix. (Not great at this GitHub thing, be advised.)