### PR TITLE
Add a Development section...

### DIFF
--- a/budgie-welcome
+++ b/budgie-welcome
@@ -228,17 +228,17 @@ class AppView(WebKit2.WebView):
                 app.update_page('.after1904', 'show')
 
         if current_page in ['budgie-applets', 'development']:
-            # applets are distro specific so need to hide/show as appropriate
+            # packages can be distro specific, so need to hide/show as appropriate
             package = app._data_path + "/config/packages.json"
 
             with open(package) as file:
                 config = json.load(file)
 
-            for applet in config['budgie-applets', 'development']:
-                if systemstate.codename in config['budgie-applets', 'development'][applet]['repos']:
-                    app.update_page("." + applet, 'show')
+            for package_name in config[current_page]:
+                if any(elem in [systemstate.codename, 'all'] for elem in config[current_page][package_name]['repos']):
+                    app.update_page("." + package_name, 'show')
                 else:
-                    app.update_page("." + applet, 'hide')
+                    app.update_page("." + pacage_name, 'hide')
 
             if systemstate.bde_version == 'NA':
                 app.update_page(".showhide", 'show')

--- a/budgie-welcome
+++ b/budgie-welcome
@@ -227,15 +227,15 @@ class AppView(WebKit2.WebView):
                 app.update_page('.before1904', 'hide')
                 app.update_page('.after1904', 'show')
 
-        if current_page == 'budgie-applets':
+        if current_page in ['budgie-applets', 'development']:
             # applets are distro specific so need to hide/show as appropriate
             package = app._data_path + "/config/packages.json"
 
             with open(package) as file:
                 config = json.load(file)
 
-            for applet in config['budgie-applets']:
-                if systemstate.codename in config['budgie-applets'][applet]['repos']:
+            for applet in config['budgie-applets', 'development']:
+                if systemstate.codename in config['budgie-applets', 'development'][applet]['repos']:
                     app.update_page("." + applet, 'show')
                 else:
                     app.update_page("." + applet, 'hide')
@@ -246,7 +246,7 @@ class AppView(WebKit2.WebView):
                 app.update_page(".showhide", 'hide')
 
         ### All pages with install/removal ###
-        if current_page in ['gettingstarted', 'default', 'recommendations', 'budgie-applets']:
+        if current_page in ['gettingstarted', 'default', 'recommendations', 'budgie-applets', 'development']:
             app.update_page('[id$=install]', 'hide')
             app.update_page('[id$=remove]', 'hide')
 

--- a/data/config/packages.json
+++ b/data/config/packages.json
@@ -1,4 +1,10 @@
 {
+  "development": {
+    "zsh": {
+      "packages": ["zsh"],
+      "repos": {"all": ["main"]}
+    }
+  },
   "budgie-applets": {
     "haste-applet": {
       "packages": ["budgie-haste-applet"],
@@ -562,16 +568,7 @@
         "cosmic": ["universe", "ppa:tista/plata-theme"],
         "disco": ["universe", "ppa:tista/plata-theme"],
         "eoan": ["universe", "ppa:tista/plata-theme"]
-      },
-    "zsh": {
-      "packages": ["zsh"],
-      "repos": {
-        "bionic": ["universe", "zsh"],
-        "cosmic": ["universe", "zsh"],
-        "disco": ["universe", "zsh"],
-        "eoan": ["universe", "zsh"]
       }
     }
     }
   }
-}

--- a/data/config/packages.json
+++ b/data/config/packages.json
@@ -562,7 +562,17 @@
         "cosmic": ["universe", "ppa:tista/plata-theme"],
         "disco": ["universe", "ppa:tista/plata-theme"],
         "eoan": ["universe", "ppa:tista/plata-theme"]
+      },
+    "zsh": {
+      "packages": [
+        "zsh"
+      ],
+      "repos": {
+        "all": [
+          "main"
+        ]
       }
     }
+    }
+    }
   }
-}

--- a/data/config/packages.json
+++ b/data/config/packages.json
@@ -3,6 +3,10 @@
     "zsh": {
       "packages": ["zsh"],
       "repos": {"all": ["main"]}
+    },
+    "fish": {
+      "packages": ["fish"],
+      "repos": {"all": ["main"]}
     }
   },
   "budgie-applets": {

--- a/data/config/packages.json
+++ b/data/config/packages.json
@@ -7,8 +7,7 @@
         "bionic": ["ppa:ubuntubudgie/backports"],
         "cosmic": ["ppa:ubuntubudgie/backports"],
         "disco": ["ppa:ubuntubudgie/backports"],
-        "eoan": ["ppa:ubuntubudgie/backports"],
-        "focal": ["ppa:ubuntubudgie/backports"]
+        "eoan": ["ppa:ubuntubudgie/backports"]
       }
     },
     "screenshot-applet": {
@@ -18,8 +17,7 @@
         "bionic": ["ppa:ubuntubudgie/backports"],
         "cosmic": ["ppa:ubuntubudgie/backports"],
         "disco": ["ppa:ubuntubudgie/backports"],
-        "eoan": ["ppa:ubuntubudgie/backports"],
-        "focal": ["ppa:ubuntubudgie/backports"]
+        "eoan": ["ppa:ubuntubudgie/backports"]
       }
     },
     "calendar-applet": {
@@ -29,8 +27,7 @@
         "bionic": ["ppa:ubuntubudgie/backports"],
         "cosmic": ["ppa:ubuntubudgie/backports"],
         "disco": ["ppa:ubuntubudgie/backports"],
-        "eoan": ["ppa:ubuntubudgie/backports"],
-        "focal": ["ppa:ubuntubudgie/backports"]
+        "eoan": ["ppa:ubuntubudgie/backports"]
       }
     },
     "advanced-brightness-controller-applet": {
@@ -45,8 +42,7 @@
     "brightness-controller-applet": {
       "packages": ["budgie-brightness-control-applet"],
       "repos": {
-        "eoan": ["ppa:ubuntubudgie/backports"],
-        "focal": ["ppa:ubuntubudgie/backports"]
+        "eoan": ["ppa:ubuntubudgie/backports"]
       }
     },
     "pixel-applet": {
@@ -55,8 +51,7 @@
         "bionic": ["ppa:ubuntubudgie/backports"],
         "cosmic": ["ppa:ubuntubudgie/backports"],
         "disco": ["ppa:ubuntubudgie/backports"],
-        "eoan": ["ppa:ubuntubudgie/backports"],
-        "focal": ["ppa:ubuntubudgie/backports"]
+        "eoan": ["ppa:ubuntubudgie/backports"]
       }
     },
     "appmenu-applet": {
@@ -65,8 +60,7 @@
         "bionic": ["universe"],
         "cosmic": ["universe"],
         "disco": ["universe"],
-        "eoan": ["universe"],
-        "focal": ["universe"]
+        "eoan": ["universe"]
       }
     },
     "weather-applet": {
@@ -84,8 +78,7 @@
         "bionic": ["ppa:ubuntubudgie/backports"],
         "cosmic": ["ppa:ubuntubudgie/backports"],
         "disco": ["ppa:ubuntubudgie/backports"],
-        "eoan": ["ppa:ubuntubudgie/backports"],
-        "focal": ["ppa:ubuntubudgie/backports"]
+        "eoan": ["ppa:ubuntubudgie/backports"]
       }
     },
     "hotcorners-applet": {
@@ -95,8 +88,7 @@
         "bionic": ["universe"],
         "cosmic": ["universe"],
         "disco": ["universe"],
-        "eoan": ["universe"],
-        "focal": ["universe"]
+        "eoan": ["universe"]
       }
     },
     "quicknote-applet": {
@@ -106,8 +98,7 @@
         "bionic": ["universe"],
         "cosmic": ["universe"],
         "disco": ["universe"],
-        "eoan": ["universe"],
-        "focal": ["universe"]
+        "eoan": ["universe"]
       }
     },
     "previews-applet": {
@@ -122,8 +113,7 @@
     "previewsapp-applet": {
       "packages": ["budgie-previews-applet"],
       "repos": {
-        "eoan": ["universe"],
-        "focal": ["universe"]
+        "eoan": ["universe"]
       }
     },
     "workspace-overview-applet": {
@@ -133,8 +123,7 @@
         "bionic": ["universe"],
         "cosmic": ["universe"],
         "disco": ["universe"],
-        "eoan": ["universe"],
-        "focal": ["universe"]
+        "eoan": ["universe"]
       }
     },
     "workspace-wallpaper-applet": {
@@ -144,8 +133,7 @@
         "bionic": ["universe"],
         "cosmic": ["universe"],
         "disco": ["universe"],
-        "eoan": ["universe"],
-        "focal": ["universe"]
+        "eoan": ["universe"]
       }
     },
     "window-mover-applet": {
@@ -155,8 +143,7 @@
         "bionic": ["universe"],
         "cosmic": ["universe"],
         "disco": ["universe"],
-        "eoan": ["universe"],
-        "focal": ["universe"]
+        "eoan": ["universe"]
       }
     },
     "showtime-applet": {
@@ -166,8 +153,7 @@
         "bionic": ["universe"],
         "cosmic": ["universe"],
         "disco": ["universe"],
-        "eoan": ["universe"],
-        "focal": ["universe"]
+        "eoan": ["universe"]
       }
     },
     "countdown-applet": {
@@ -177,8 +163,7 @@
         "bionic": ["universe"],
         "cosmic": ["universe"],
         "disco": ["universe"],
-        "eoan": ["universe"],
-        "focal": ["universe"]
+        "eoan": ["universe"]
       }
     },
     "keyboard-language-applet": {
@@ -188,8 +173,7 @@
         "bionic": ["universe"],
         "cosmic": ["universe"],
         "disco": ["universe"],
-        "eoan": ["universe"],
-        "focal": ["universe"]
+        "eoan": ["universe"]
       }
     },
     "rotation-lock-applet": {
@@ -199,8 +183,7 @@
         "bionic": ["universe"],
         "cosmic": ["universe"],
         "disco": ["universe"],
-        "eoan": ["universe"],
-        "focal": ["universe"]
+        "eoan": ["universe"]
       }
     },
     "clockworks-applet": {
@@ -210,8 +193,7 @@
         "bionic": ["universe"],
         "cosmic": ["universe"],
         "disco": ["universe"],
-        "eoan": ["universe"],
-        "focal": ["universe"]
+        "eoan": ["universe"]
       }
     },
     "dropby-applet": {
@@ -226,15 +208,13 @@
     "dropby-window-applet": {
       "packages": ["budgie-dropby-applet"],
       "repos": {
-        "eoan": ["universe"],
-        "focal": ["universe"]
+        "eoan": ["universe"]
       }
     },
     "brightness-controller-applet": {
       "packages": ["budgie-brightness-controller-applet"],
       "repos": {
-        "eoan": ["universe"],
-        "focal": ["universe"]
+        "eoan": ["universe"]
       }
     },
     "browser-profile-launcher-applet": {
@@ -243,8 +223,7 @@
         "bionic": ["ppa:ubuntubudgie/backports"],
         "cosmic": ["ppa:ubuntubudgie/backports"],
         "disco": ["ppa:ubuntubudgie/backports"],
-        "eoan": ["ppa:ubuntubudgie/backports"],
-        "focal": ["ppa:ubuntubudgie/backports"]
+        "eoan": ["ppa:ubuntubudgie/backports"]
       }
     },
     "kangaroo-applet": {
@@ -253,8 +232,7 @@
         "bionic": ["ppa:ubuntubudgie/backports"],
         "cosmic": ["universe"],
         "disco": ["universe"],
-        "eoan": ["universe"],
-        "focal": ["universe"]
+        "eoan": ["universe"]
       }
     },
     "weathershow-applet": {
@@ -263,8 +241,7 @@
         "bionic": ["ppa:ubuntubudgie/backports"],
         "cosmic": ["universe"],
         "disco": ["universe"],
-        "eoan": ["universe"],
-        "focal": ["universe"]
+        "eoan": ["universe"]
       }
     },
     "recentlyused-applet": {
@@ -273,8 +250,7 @@
         "bionic": ["ppa:ubuntubudgie/backports"],
         "cosmic": ["universe"],
         "disco": ["universe"],
-        "eoan": ["universe"],
-        "focal": ["universe"]
+        "eoan": ["universe"]
       }
     },
     "trash-applet": {
@@ -283,8 +259,7 @@
         "bionic": ["ppa:ubuntubudgie/backports"],
         "cosmic": ["universe"],
         "disco": ["universe"],
-        "eoan": ["universe"],
-        "focal": ["universe"]
+        "eoan": ["universe"]
       }
     },
     "applauncher-applet": {
@@ -293,8 +268,7 @@
         "bionic": ["ppa:ubuntubudgie/backports"],
         "cosmic": ["universe"],
         "disco": ["universe"],
-        "eoan": ["universe"],
-        "focal": ["universe"]
+        "eoan": ["universe"]
       }
     },
     "network-applet": {
@@ -303,8 +277,7 @@
         "bionic": ["ppa:ubuntubudgie/backports"],
         "cosmic": ["ppa:ubuntubudgie/backports"],
         "disco": ["ppa:ubuntubudgie/backports"],
-        "eoan": ["ppa:ubuntubudgie/backports"],
-        "focal": ["ppa:ubuntubudgie/backports"]
+        "eoan": ["ppa:ubuntubudgie/backports"]
       }
     },
     "cpufreq-applet": {
@@ -313,8 +286,7 @@
         "bionic": ["ppa:ubuntubudgie/backports"],
         "cosmic": ["ppa:ubuntubudgie/backports"],
         "disco": ["ppa:ubuntubudgie/backports"],
-        "eoan": ["ppa:ubuntubudgie/backports"],
-        "focal": ["ppa:ubuntubudgie/backports"]
+        "eoan": ["ppa:ubuntubudgie/backports"]
       }
     },
     "sys-monitor-applet": {
@@ -323,8 +295,7 @@
         "bionic": ["ppa:ubuntubudgie/backports"],
         "cosmic": ["ppa:ubuntubudgie/backports"],
         "disco": ["ppa:ubuntubudgie/backports"],
-        "eoan": ["ppa:ubuntubudgie/backports"],
-        "focal": ["ppa:ubuntubudgie/backports"]
+        "eoan": ["ppa:ubuntubudgie/backports"]
       }
     },
     "takeabreak-applet": {
@@ -333,36 +304,31 @@
         "bionic": ["ppa:ubuntubudgie/backports"],
         "cosmic": ["ppa:ubuntubudgie/backports"],
         "disco": ["universe"],
-        "eoan": ["universe"],
-        "focal": ["universe"]
+        "eoan": ["universe"]
       }
     },
     "fuzzyclock-applet": {
       "packages": ["budgie-fuzzyclock-applet"],
       "repos": {
-        "eoan": ["universe"],
-        "focal": ["universe"]
+        "eoan": ["universe"]
       }
     },
     "workspace-stopwatch-applet": {
       "packages": ["budgie-workspace-stopwatch-applet"],
       "repos": {
-        "eoan": ["universe"],
-        "focal": ["universe"]
+        "eoan": ["universe"]
       }
     },
     "quickchar": {
       "packages": ["budgie-quickchar"],
       "repos": {
-        "eoan": ["universe"],
-        "focal": ["universe"]
+        "eoan": ["universe"]
       }
     },
     "sntray-applet": {
       "packages": ["budgie-sntray-plugin"],
       "repos": {
-        "eoan": ["universe"],
-        "focal": ["universe"]
+        "eoan": ["universe"]
       }
     }
   },
@@ -377,8 +343,7 @@
         "bionic": ["universe"],
         "cosmic": ["universe"],
         "disco": ["universe"],
-        "eoan": ["universe"],
-        "focal": ["universe"]
+        "eoan": ["universe"]
       },
       "post-install": "flatpak-setup"
     },
@@ -409,8 +374,7 @@
         "bionic": ["ppa:ubuntubudgie/backports"],
         "cosmic": ["ppa:ubuntubudgie/backports"],
         "disco": ["ppa:ubuntubudgie/backports"],
-        "eoan": ["ppa:ubuntubudgie/backports"],
-        "focal": ["ppa:ubuntubudgie/backports"]
+        "eoan": ["ppa:ubuntubudgie/backports"]
       }
     },
     "dropbox": {
@@ -423,16 +387,14 @@
       "packages": ["nemo-dropbox"],
       "repos": {
         "disco": ["ppa:ubuntubudgie/backports"],
-        "eoan": ["ppa:ubuntubudgie/backports"],
-        "focal": ["ppa:ubuntubudgie/backports"]
+        "eoan": ["ppa:ubuntubudgie/backports"]
       }
     },
     "nemoshare": {
       "packages": ["nemo-share"],
       "repos": {
         "disco": ["ppa:ubuntubudgie/backports"],
-        "eoan": ["ppa:ubuntubudgie/backports"],
-        "focal": ["ppa:ubuntubudgie/backports"]
+        "eoan": ["ppa:ubuntubudgie/backports"]
       }
     }
   },
@@ -538,8 +500,7 @@
         "bionic": ["universe", "ppa:tista/adapta"],
         "cosmic": ["universe", "ppa:tista/adapta"],
         "disco": ["universe"],
-        "eoan": ["universe"],
-        "focal": ["universe"]
+        "eoan": ["universe"]
       }
     },
     "material-vimix-theme": {
@@ -549,8 +510,7 @@
         "bionic": ["universe", "ppa:ubuntubudgie/backports"],
         "cosmic": ["universe", "ppa:ubuntubudgie/backports"],
         "disco": ["universe", "ppa:ubuntubudgie/backports"],
-        "eoan": ["universe", "ppa:ubuntubudgie/backports"],
-        "focal": ["universe", "ppa:ubuntubudgie/backports"]
+        "eoan": ["universe", "ppa:ubuntubudgie/backports"]
       }
     },
     "material-materia-theme": {
@@ -565,8 +525,7 @@
         "bionic": ["universe", "ppa:numix/ppa"],
         "cosmic": ["universe", "ppa:numix/ppa"],
         "disco": ["universe", "ppa:numix/ppa"],
-        "eoan": ["universe", "ppa:numix/ppa"],
-        "focal": ["universe", "ppa:numix/ppa"]
+        "eoan": ["universe", "ppa:numix/ppa"]
       }
     },
     "vertex-theme": {
@@ -584,8 +543,7 @@
         "bionic": ["universe", "ppa:ubuntubudgie/backports"],
         "cosmic": ["universe", "ppa:ubuntubudgie/backports"],
         "disco": ["universe", "ppa:ubuntubudgie/backports"],
-        "eoan": ["universe", "ppa:ubuntubudgie/backports"],
-        "focal": ["universe", "ppa:ubuntubudgie/backports"]
+        "eoan": ["universe", "ppa:ubuntubudgie/backports"]
       }
     },
     "ant-theme": {
@@ -594,8 +552,7 @@
         "bionic": ["universe", "ppa:ubuntubudgie/backports"],
         "cosmic": ["universe", "ppa:ubuntubudgie/backports"],
         "disco": ["universe", "ppa:ubuntubudgie/backports"],
-        "eoan": ["universe", "ppa:ubuntubudgie/backports"],
-        "focal": ["universe", "ppa:ubuntubudgie/backports"]
+        "eoan": ["universe", "ppa:ubuntubudgie/backports"]
       }
     },
     "plata-theme": {
@@ -604,23 +561,17 @@
         "bionic": ["universe", "ppa:tista/plata-theme"],
         "cosmic": ["universe", "ppa:tista/plata-theme"],
         "disco": ["universe", "ppa:tista/plata-theme"],
-<<<<<<< HEAD
         "eoan": ["universe", "ppa:tista/plata-theme"]
       },
     "zsh": {
-      "packages": [
-        "zsh"
-      ],
+      "packages": ["zsh"],
       "repos": {
-        "all": [
-          "main"
-        ]
-=======
-        "eoan": ["universe", "ppa:tista/plata-theme"],
-        "focal": ["universe", "ppa:tista/plata-theme"]
->>>>>>> f2493c22fa174806172cdcc9469605fe944020c0
+        "bionic": ["universe", "zsh"],
+        "cosmic": ["universe", "zsh"],
+        "disco": ["universe", "zsh"],
+        "eoan": ["universe", "zsh"]
       }
     }
     }
-    }
   }
+}

--- a/data/development.html
+++ b/data/development.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link href="css/bootstrap.min.css" rel="stylesheet" media="screen">
+    <link href="css/material-icons.css" rel="stylesheet" media="screen">
+    <link href="css/animate.css" rel="stylesheet" media="screen">
+    <link href="css/welcome.css" rel="stylesheet" media="screen">
+    <link href="css/baguetteBox.min.css" rel="stylesheet" media="screen">
+</head>
+
+<body class="backdrop-simple fade fade-1s" onload="sortAppletList();">
+    <div id="wrapper">
+        <div id="title-inject">&zwnj;Ubuntu Budgie Development Tools&zwnj;</div>
+        <div id="content" class="container entire-page-fade">
+            <b>&zwnj;This is a quick and handy way to install some development tools for Ubuntu Budgie.&zwnj;</b>
+            </div>
+            <br>
+            <div class="row text-md-center" id="applet-list">
+                <div class="col-md-6 haste-applet">
+                    <br>
+                    <h2><a onclick="cmd('link?https://github.com/zsh-users/zsh')"><span
+                                class="material-icons">help</span></a>&zwnj;Zsh Shell (Command Line)&zwnj;</h2>
+                    <div class="card card-block">
+                        <p class="card-text">&zwnj;Zsh, an amazing shell for both power users and beginners which provides simplicity yet perfection. Used for terminal commands, don't play around with this if you don't know what it does.&zwnj;</p>
+                    </div>
+                    <div class="text-md-right">
+                        <a id="zsh-remove" class="btn btn-danger" onclick="cmd('remove?zsh');cmd('')">
+                            <span class="material-icons">&#xE872;</span><span
+                                class="button-text">&zwnj;Remove&zwnj;</span>
+                        </a>
+                        <a id="zsh-install" class="btn btn-success hvr-shadow"
+                            onclick="cmd('install?zsh');cmd('')"> &nbsp;
+                            <span class="material-icons">&#xE2C0;</span>&zwnj;Install Applet&zwnj;&nbsp;
+                        </a>
+                        <span id="haste-status" class="hidden">
+                            <img src="img/welcome/processing.gif" width="24px" height="24px" /> &zwnj;Applying
+                            Changes...&zwnj;
+                        </span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <script src="js/jquery-2.1.4.js"></script>
+    <script src="js/tether.js"></script>
+    <script src="js/bootstrap.min.js"></script>
+    <script src="js/janimate.js"></script>
+    <script src="js/confetti.js"></script> <!-- Confetti only appears on special events -->
+    <script src="js/welcome.js"></script>
+    <script src="js/baguetteBox.min.js"></script>
+    <script type="text/javascript">
+        baguetteBox.run('[data-toggle="lightbox"]', {
+            // Custom options
+        });
+    </script>
+</body>
+
+</html>

--- a/data/development.html
+++ b/data/development.html
@@ -15,11 +15,11 @@
     <div id="wrapper">
         <div id="title-inject">&zwnj;Ubuntu Budgie Development Tools&zwnj;</div>
         <div id="content" class="container entire-page-fade">
-            <b>&zwnj;This is a quick and handy way to install some development tools for Ubuntu Budgie.&zwnj;</b>
+            <b>&zwnj;This is a quick and handy way to install some development tools for Ubuntu Budgie. Note that the command line shells usually don't auto apply - read https://www.tecmint.com/change-a-users-default-shell-in-linux/&zwnj;</b>
             </div>
             <br>
-            <div class="row text-md-center" id="applet-list">
-                <div class="col-md-6 haste-applet">
+            <div class="row text-md-center" id="package-list">
+                <div class="col-md-6 zsh">
                     <br>
                     <h2><a onclick="cmd('link?https://github.com/zsh-users/zsh')"><span
                                 class="material-icons">help</span></a>&zwnj;Zsh Shell (Command Line)&zwnj;</h2>
@@ -33,9 +33,30 @@
                         </a>
                         <a id="zsh-install" class="btn btn-success hvr-shadow"
                             onclick="cmd('install?zsh');cmd('')"> &nbsp;
-                            <span class="material-icons">&#xE2C0;</span>&zwnj;Install Applet&zwnj;&nbsp;
+                            <span class="material-icons">&#xE2C0;</span>&zwnj;Install&zwnj;&nbsp;
                         </a>
-                        <span id="haste-status" class="hidden">
+                        <span id="zsh-status" class="hidden">
+                            <img src="img/welcome/processing.gif" width="24px" height="24px" /> &zwnj;Applying
+                            Changes...&zwnj;
+                        </span>
+                    </div>
+                </div>
+                <div class="col-md-6 fish">
+                    <br>
+                    <h2><a onclick="cmd('link?http://fishshell.com/')"><span class="material-icons">help</span></a>&zwnj;Fish
+                        Shell (Command Line)&zwnj;</h2>
+                    <div class="card card-block">
+                        <p class="card-text">&zwnj;Fish is an even easier Linux shell to use. It works really great and has features such as fancy colors and a clean syntax. NOTE: Fish syntax varies even more from bash then zsh. Therefore, install only if you know what you're doing.
+                            .&zwnj;</p>
+                    </div>
+                    <div class="text-md-right">
+                        <a id="fish-remove" class="btn btn-danger" onclick="cmd('remove?fish');cmd('')">
+                            <span class="material-icons">&#xE872;</span><span class="button-text">&zwnj;Remove&zwnj;</span>
+                        </a>
+                        <a id="fish-install" class="btn btn-success hvr-shadow" onclick="cmd('install?fish');cmd('')"> &nbsp;
+                            <span class="material-icons">&#xE2C0;</span>&zwnj;Install&zwnj;&nbsp;
+                        </a>
+                        <span id="fish-status" class="hidden">
                             <img src="img/welcome/processing.gif" width="24px" height="24px" /> &zwnj;Applying
                             Changes...&zwnj;
                         </span>
@@ -47,7 +68,7 @@
     <script src="js/jquery-2.1.4.js"></script>
     <script src="js/tether.js"></script>
     <script src="js/bootstrap.min.js"></script>
-    <script src="js/janimate.js"></script>
+    <script src="js/janimate.js"></script>      
     <script src="js/confetti.js"></script> <!-- Confetti only appears on special events -->
     <script src="js/welcome.js"></script>
     <script src="js/baguetteBox.min.js"></script>

--- a/data/index.html
+++ b/data/index.html
@@ -119,6 +119,7 @@
                   Apps&zwnj;</a>
                 <a class="dropdown-item" href="#" onclick="cmd('link?https://flathub.org/apps.html')">&zwnj;Flatpak
                   Apps&zwnj;</a>
+                <a class="dropdown-item" href="#" onclick="smoothPageFade('development.html');cmd('')">&zwnj;Development&zwnj;</a>
               </div>
             </div>
           </div>


### PR DESCRIPTION
My PR, with help from @fossfreedom, adds a functioning Development section to the Install Software dropdown, currently only containing the `zsh` and `fish` shells. 
