### PR TITLE
Fixed "data/gettingstarted.html"

### DIFF
--- a/data/gettingstarted.html
+++ b/data/gettingstarted.html
@@ -273,8 +273,8 @@
                 <p>
                   <img class="left" src="img/applications/gparted.png" />
                   &zwnj;<b>GParted</b> is available during the live session only.
-                  It is located under the <b>System <i class="material-icons">&#xE315;</i>
-                    Administration</b> menu. GParted provides complete flexibility over your partitions,
+                  It is located under the <b>System Tools <i class="material-icons">&#xE315;</i>
+                    GParted</b> menu. GParted provides complete flexibility over your partitions,
                   primarily for power users who know how they'd like to layout their disks.
                   This method makes changes to partitions prior to installation.&zwnj;
                 </p>
@@ -418,8 +418,8 @@
                 <span id="updates-hint" class="center">
                   <small>
                     <p>
-                      &zwnj;<b>Software Updater</b> can be found later in
-                      <strong>Application Menu</strong>&zwnj;
+                      &zwnj;<b>Software Updater</b> can be found later in the menu
+                      <strong> Administration</strong>&zwnj;
                     </p>
                   </small>
                 </span>
@@ -780,8 +780,8 @@
                   class="button-text">&zwnj;Configure Backup&zwnj;</span>&nbsp;
               </a>
               <span id="backup-hint" class="center"><small>
-                  <p><i class="material-icons">&#xE88F;</i> &zwnj;<b>Backups</b> can be found later in
-                    <b>Application Menu <i class="material-icons">&#xE315;</i> Backup</b>.&zwnj;</p>
+                  <p><i class="material-icons">&#xE88F;</i> &zwnj;<b>Backups</b> can be found later in the menu
+                    <b> Utilities <i class="material-icons">&#xE315;</i> Backups</b>.&zwnj;</p>
                 </small></span>
             </div>
           </div>


### PR DESCRIPTION
The menu structure of the "data/gettingstarted.html" file is different from the menu of the Budgie menu of Ubuntu Budgie. I noticed while translating.

1. gettingstarted.html:275: GParted:
System Tools > GParted

2. gettingstarted.html:421: Software Updater:
Administration > Software Updater

3. gettingstarted.html:783: Backups:
Utilities > Backups
