### PR TITLE
Fixed minor spacing issues

### DIFF
--- a/budgie-welcome
+++ b/budgie-welcome
@@ -366,7 +366,7 @@ class AppView(WebKit2.WebView):
         elif uri == 'users':
             subprocess.Popen([control_center, 'user-accounts'])
         elif uri == 'backup':
-            subprocess.Popen(['deja-dup-preferences'])
+            subprocess.Popen(['backup'])
         elif uri == 'firewall':
             subprocess.Popen(['gufw'])
         elif uri == 'budgie-desktop-settings':

--- a/budgie-welcome
+++ b/budgie-welcome
@@ -366,7 +366,7 @@ class AppView(WebKit2.WebView):
         elif uri == 'users':
             subprocess.Popen([control_center, 'user-accounts'])
         elif uri == 'backup':
-            subprocess.Popen(['backup'])
+            subprocess.Popen(['deja-dup'])
         elif uri == 'firewall':
             subprocess.Popen(['gufw'])
         elif uri == 'budgie-desktop-settings':

--- a/data/gettingstarted.html
+++ b/data/gettingstarted.html
@@ -793,8 +793,8 @@
               &zwnj;Applying Changes...&zwnj;</span>
             <a id="flatpak-install" class="btn btn-success" onclick="cmd('install?flatpak');">&nbsp;<span 
               class="material-icons">&#xE2C0;</span><span class="button-text">&zwnj;Install & Configure Flatpak&zwnj;</span>&nbsp;</a>
-            <span id="flatpak-remove" class="alert alert-success"> <i class="material-icons">&#xE876;</i>&zwnj;Flatpak is installed. 
-              Please reboot for the service to start&zwnj;</span>
+            <div id="flatpak-remove" class="alert alert-success"> <i class="material-icons">&#xE876;</i>&zwnj;Flatpak is installed. 
+              Please reboot for the service to start&zwnj;</div>
             <span id="flatpak-hint" class="center"><small>
                 <p>&zwnj;Being a user friendly distribution, Ubuntu Budgie allows you to install Flatpak with a single click. 
                   After setup, you can use <strong>Software</strong> to install Flatpak applications.&zwnj;

--- a/data/gettingstarted.html
+++ b/data/gettingstarted.html
@@ -806,7 +806,7 @@
         
         <div class="row wow fadeIn">
           <div class="col-md-6 center-inside">
-            <img src="img/logos/dropbox.png" style="width: 100%">
+            <img src="img/logos/dropbox.png">
           </div>
           <div class="col-md-6">
             <h3>&zwnj;Dropbox&zwnj;</h3>

--- a/data/gettingstarted.html
+++ b/data/gettingstarted.html
@@ -812,14 +812,14 @@
             <h3>&zwnj;Dropbox&zwnj;</h3>
             <p>&zwnj;<strong>Dropbox</strong> is a popular proprietary file sharing
               and storage solution.&zwnj;</p>
-            <span id="nemodropbox-status" class="hidden"><img src="img/welcome/processing.gif" width="24px" height="24px" /> 
+            <span id="dropbox-status" class="hidden"><img src="img/welcome/processing.gif" width="24px" height="24px" /> 
               &zwnj;Applying Changes...&zwnj;</span>
-            <a id="nemodropbox-install" class="btn btn-success hvr-shadow" onclick="cmd('install?nemodropbox');"> 
+            <a id="dropbox-install" class="btn btn-success hvr-shadow" onclick="cmd('install?dropbox');"> 
               &nbsp;<span class="material-icons">&#xE2C0;</span>&zwnj;Install & Configure Dropbox&zwnj;&nbsp;
             </a>
-            <div id="nemodropbox-remove" class="alert alert-success">
+            <div id="dropbox-remove" class="alert alert-success">
               <i class="material-icons">&#xE876;</i>&zwnj;Dropbox is installed&zwnj;</span>
-              <span id="nemodropbox-hint" class="center"><small>
+              <span id="dropbox-hint" class="center"><small>
                 <p>&zwnj;After installing, logout and login and follow the dropbox instructions that are
                   then displayed.&zwnj;</p>
                 </small></span>

--- a/data/recommendations.html
+++ b/data/recommendations.html
@@ -50,7 +50,7 @@
                         </div>
                         <div class="text-md-right">
                             <div id="backup-remove">
-                            <a class="btn btn-inverse" onclick="cmd('backup');">
+                            <a class="btn btn-inverse" onclick="cmd('deja-dup');">
                                 &nbsp;<img class="button-icon" src="img/applications/deja-dup.png" />&nbsp;<span
                                 class="button-text">&zwnj;Configure Backup&zwnj;</span>&nbsp;
                             </a>
@@ -86,7 +86,7 @@
                             <div id="firewall-remove">
                             <a class="btn btn-inverse" onclick="cmd('firewall');">
                                 &nbsp;<img class="button-icon" src="img/applications/gufw.png" />&nbsp;<span
-                                class="button-text">&zwnj;Configure Firewall&zwnj;</span>&nbsp;
+                                class="button-text">&zwnj;Configure Firewall &zwnj;</span>&nbsp;
                             </a>
                             <span id="firewall-hint" class="center"><small>
                                 <p><i class="material-icons">&#xE88F;</i> <b>&zwnj;Firewall Configuration</b> can be found later in the menu

--- a/data/recommendations.html
+++ b/data/recommendations.html
@@ -54,15 +54,15 @@
                                 &nbsp;<img class="button-icon" src="img/applications/deja-dup.png" />&nbsp;<span
                                 class="button-text">&zwnj;Configure Backup&zwnj;</span>&nbsp;
                             </a>
+                            <a class="btn btn-danger" onclick="cmd('remove?backup');">
+                                <span class="material-icons">&#xE872;</span><span
+                                    class="button-text">&zwnj;Remove&zwnj;</span>
+                            </a>
                             <span id="backup-hint" class="center"><small>
                                 <p><i class="material-icons">&#xE88F;</i> &zwnj;<b>Backups</b> can be found later in the menu
                                     <b>Utilities <i class="material-icons">&#xE315;</i> Backups</b>.&zwnj;
                                 </p>
                                 </small></span>
-                            <a class="btn btn-danger" onclick="cmd('remove?backup');">
-                                <span class="material-icons">&#xE872;</span><span
-                                    class="button-text">&zwnj;Remove&zwnj;</span>
-                            </a>
                             </div>
                             <a id="backup-install" class="btn btn-success" onclick="cmd('install?backup');">&nbsp;<span
                                 class="material-icons">&#xE2C0;</span><span class="button-text">&zwnj;Install Deja-Dup&zwnj;</span>&nbsp;</a>
@@ -90,7 +90,11 @@
                             <div id="firewall-remove">
                             <a class="btn btn-inverse" onclick="cmd('firewall');">
                                 &nbsp;<img class="button-icon" src="img/applications/gufw.png" />&nbsp;<span
-                                class="button-text">&zwnj;Configure Firewall &zwnj;</span>&nbsp;
+                                class="button-text">&zwnj;Configure Firewall&zwnj;</span>&nbsp;
+                            </a>
+                            <a class="btn btn-danger" onclick="cmd('remove?firewall');">
+                                <span class="material-icons">&#xE872;</span><span
+                                    class="button-text">&zwnj;Remove&zwnj;</span>
                             </a>
                             <span id="firewall-hint" class="center"><small>
                                 <p><i class="material-icons">&#xE88F;</i> <b>&zwnj;Firewall Configuration</b> can be found later in the menu
@@ -115,12 +119,16 @@
                                 light-weight, on-demand scanner for Linux systems.&zwnj;</p>
                         </div>
                         <div class="text-md-right">
-                            <span id="clamav-remove" class="alert alert-success"> <i
-                                    class="material-icons">&#xE876;</i>&zwnj;ClamAV is installed&zwnj;</span><a
-                                id="clamav-install" class="btn btn-success hvr-shadow"
-                                onclick="cmd('install?clamav');"> &nbsp;<span
+                            <span id="clamav-remove" class="alert alert-success"> 
+                                <i class="material-icons">&#xE876;</i>&zwnj;ClamAV is installed&zwnj;</span>
+                                <a id="clamav-install" class="btn btn-success hvr-shadow" onclick="cmd('install?clamav');"> &nbsp;<span
                                     class="material-icons">&#xE2C0;</span>&zwnj;Install & Configure
-                                ClamAV&zwnj;&nbsp;</a>
+                                ClamAV&zwnj;&nbsp;
+                                </a>
+                                <a class="btn btn-danger" onclick="cmd('remove?clamav');">
+                                    <span class="material-icons">&#xE872;</span><span
+                                        class="button-text">&zwnj;Remove&zwnj;</span>
+                                </a>
                             <span id="clamav-status" class="hidden"><img src="img/welcome/processing.gif"
                                     width="24px" height="24px" /> &zwnj;Applying Changes...&zwnj;</span>
                         </div>
@@ -132,11 +140,14 @@
                             <p>&zwnj;Nemo Preview allows you to quickly view the contents of a highlighted file from the Nemo file manager. Just press space to toggle the preview on and off.&zwnj;</p>
                         </div>
                         <div class="text-md-right">
-                            <span id="nemopreview-remove" class="alert alert-success"> <i
-                                    class="material-icons">&#xE876;</i>&zwnj;Nemo Preview is installed&zwnj;</span><a
-                                id="nemopreview-install" class="btn btn-success hvr-shadow"
-                                onclick="cmd('install?nemopreview');"> &nbsp;<span
-                                    class="material-icons">&#xE2C0;</span>&zwnj;Install Nemo Preview&zwnj;&nbsp;</a>
+                            <span id="nemopreview-remove" class="alert alert-success"> <i class="material-icons">&#xE876;</i>&zwnj;Nemo Preview is installed&zwnj;</span>
+                            <a id="nemopreview-install" class="btn btn-success hvr-shadow" onclick="cmd('install?nemopreview');"> &nbsp;<span
+                                    class="material-icons">&#xE2C0;</span>&zwnj;Install Nemo Preview&zwnj;&nbsp;
+                            </a>
+                            <a class="btn btn-danger" onclick="cmd('remove?nemopreview');">
+                                <span class="material-icons">&#xE872;</span><span
+                                    class="button-text">&zwnj;Remove&zwnj;</span>
+                            </a>
                             <span id="nemopreview-status" class="hidden"><img src="img/welcome/processing.gif"
                                     width="24px" height="24px" /> &zwnj;Applying Changes...&zwnj;</span>
                         </div>
@@ -150,10 +161,14 @@
                         </div>
                         <div class="text-md-right">
                             <span id="nemoshare-remove" class="alert alert-success"> <i
-                                    class="material-icons">&#xE876;</i>&zwnj;Nemo Share is installed&zwnj;</span><a
-                                id="nemoshare-install" class="btn btn-success hvr-shadow"
-                                onclick="cmd('install?nemoshare');"> &nbsp;<span
-                                    class="material-icons">&#xE2C0;</span>&zwnj;Install Nemo Share&zwnj;&nbsp;</a>
+                                    class="material-icons">&#xE876;</i>&zwnj;Nemo Share is installed&zwnj;</span>\
+                                <a id="nemoshare-install" class="btn btn-success hvr-shadow" onclick="cmd('install?nemoshare');"> &nbsp;<span
+                                    class="material-icons">&#xE2C0;</span>&zwnj;Install Nemo Share&zwnj;&nbsp;
+                                </a>
+                                <a class="btn btn-danger" onclick="cmd('remove?nemoshare');">
+                                        <span class="material-icons">&#xE872;</span><span
+                                            class="button-text">&zwnj;Remove&zwnj;</span>
+                                </a>
                             <span id="nemoshare-status" class="hidden"><img src="img/welcome/processing.gif"
                                     width="24px" height="24px" /> &zwnj;Applying Changes...&zwnj;</span>
                         </div>
@@ -166,11 +181,15 @@
                                 of printer drivers which includes drivers for Epson and Canon printers. Gutenprint supports only the printer part of multi-function devices.&zwnj;</p>
                         </div>
                         <div class="text-md-right">
-                            <span id="gutenprint-remove" class="alert alert-success"> <i
-                                    class="material-icons">&#xE876;</i>&zwnj;Gutenprint is installed&zwnj;</span><a
-                                id="gutenprint-install" class="btn btn-success hvr-shadow"
+                            <span id="gutenprint-remove" class="alert alert-success"> <i class="material-icons">&#xE876;</i>&zwnj;Gutenprint is installed&zwnj;</span>
+                            <a id="gutenprint-install" class="btn btn-success hvr-shadow"
                                 onclick="cmd('install?gutenprint');"> &nbsp;<span
-                                    class="material-icons">&#xE2C0;</span>&zwnj;Install Gutenprint&zwnj;&nbsp;</a>
+                                    class="material-icons">&#xE2C0;</span>&zwnj;Install Gutenprint&zwnj;&nbsp;
+                            </a>
+                            <a class="btn btn-danger" onclick="cmd('remove?gutenprint');">
+                                <span class="material-icons">&#xE872;</span><span
+                                    class="button-text">&zwnj;Remove&zwnj;</span>
+                            </a>
                             <span id="gutenprint-status" class="hidden"><img src="img/welcome/processing.gif"
                                     width="24px" height="24px" /> &zwnj;Applying Changes...&zwnj;</span>
                         </div>

--- a/data/recommendations.html
+++ b/data/recommendations.html
@@ -146,10 +146,11 @@
                             <a id="nemopreview-install" class="btn btn-success hvr-shadow" onclick="cmd('install?nemopreview');"> &nbsp;<span
                                     class="material-icons">&#xE2C0;</span>&zwnj;Install Nemo Preview&zwnj;&nbsp;
                             </a>
+                            <!-- FIXME: Causes css issues & doesn't hide itself when package is installed; functionality does working though
                             <a class="btn btn-danger" onclick="cmd('remove?nemopreview');">
                                 <span class="material-icons">&#xE872;</span><span
                                     class="button-text">&zwnj;Remove&zwnj;</span>
-                            </a>
+                            </a> -->
                             <span id="nemopreview-status" class="hidden"><img src="img/welcome/processing.gif"
                                     width="24px" height="24px" /> &zwnj;Applying Changes...&zwnj;</span>
                         </div>
@@ -167,9 +168,9 @@
                                 <a id="nemoshare-install" class="btn btn-success hvr-shadow" onclick="cmd('install?nemoshare');"> &nbsp;<span
                                     class="material-icons">&#xE2C0;</span>&zwnj;Install Nemo Share&zwnj;&nbsp;
                                 </a>
-                                <a class="btn btn-danger" onclick="cmd('remove?nemoshare');">
+                                <!-- <a class="btn btn-danger" onclick="cmd('remove?nemoshare');">
                                         <span class="material-icons">&#xE872;</span><span
-                                            class="button-text">&zwnj;Remove&zwnj;</span>
+                                            class="button-text">&zwnj;Remove&zwnj;</span> -->
                                 </a>
                             <span id="nemoshare-status" class="hidden"><img src="img/welcome/processing.gif"
                                     width="24px" height="24px" /> &zwnj;Applying Changes...&zwnj;</span>
@@ -188,10 +189,10 @@
                                 onclick="cmd('install?gutenprint');"> &nbsp;<span
                                     class="material-icons">&#xE2C0;</span>&zwnj;Install Gutenprint&zwnj;&nbsp;
                             </a>
-                            <a class="btn btn-danger" onclick="cmd('remove?gutenprint');">
+                            <!-- <a class="btn btn-danger" onclick="cmd('remove?gutenprint');">
                                 <span class="material-icons">&#xE872;</span><span
                                     class="button-text">&zwnj;Remove&zwnj;</span>
-                            </a>
+                            </a> -->
                             <span id="gutenprint-status" class="hidden"><img src="img/welcome/processing.gif"
                                     width="24px" height="24px" /> &zwnj;Applying Changes...&zwnj;</span>
                         </div>

--- a/data/recommendations.html
+++ b/data/recommendations.html
@@ -141,18 +141,20 @@
                         <div class="card card-block">
                             <p>&zwnj;Nemo Preview allows you to quickly view the contents of a highlighted file from the Nemo file manager. Just press space to toggle the preview on and off.&zwnj;</p>
                         </div>
-                        <div class="text-md-right nemopreview-remove">
-                            <span id="nemopreview-remove" class="alert alert-success"> <i class="material-icons">&#xE876;</i>&zwnj;Nemo Preview is installed&zwnj;</span>
-                            <a class="btn btn-danger" onclick="cmd('remove?nemopreview');">
-                                <span class="material-icons">&#xE872;</span><span
-                                class="button-text">&zwnj;Remove&zwnj;</span>
+                        <div class="text-md-right">
+                            <div class="nemopreview-remove">
+                                <span id="nemopreview-remove" class="alert alert-success"> <i class="material-icons">&#xE876;</i>&zwnj;Nemo Preview is installed&zwnj;</span>
+                                <a class="btn btn-danger" onclick="cmd('remove?nemopreview');">
+                                    <span class="material-icons">&#xE872;</span><span
+                                    class="button-text">&zwnj;Remove&zwnj;</span>
+                                </a>
+                                <span id="nemopreview-status" class="hidden"><img src="img/welcome/processing.gif"
+                                    width="24px" height="24px" /> &zwnj;Applying Changes...&zwnj;</span>
+                            </div>
+                            <a id="nemopreview-install" class="btn btn-success hvr-shadow" onclick="cmd('install?nemopreview');"> &nbsp;<span
+                                    class="material-icons">&#xE2C0;</span>&zwnj;Install Nemo Preview&zwnj;&nbsp;
                             </a>
-                            <span id="nemopreview-status" class="hidden"><img src="img/welcome/processing.gif"
-                                width="24px" height="24px" /> &zwnj;Applying Changes...&zwnj;</span>
                         </div>
-                        <a id="nemopreview-install" class="btn btn-success hvr-shadow" onclick="cmd('install?nemopreview');"> &nbsp;<span
-                                class="material-icons">&#xE2C0;</span>&zwnj;Install Nemo Preview&zwnj;&nbsp;
-                        </a>
                         <hr />
                     </div>
                     <div>
@@ -161,19 +163,21 @@
                             <p>&zwnj;Nemo Share allows you to quickly share a folder from the Nemo file manager without
                                 requiring root access.&zwnj;</p>
                         </div>
-                        <div class="text-md-right nemoshare-remove">
-                            <span id="nemoshare-remove" class="alert alert-success"> <i
-                                    class="material-icons">&#xE876;</i>&zwnj;Nemo Share is installed&zwnj;</span>
-                                <a class="btn btn-danger" onclick="cmd('remove?nemoshare');">
-                                        <span class="material-icons">&#xE872;</span><span
-                                            class="button-text">&zwnj;Remove&zwnj;</span>
-                                </a>
-                            <span id="nemoshare-status" class="hidden"><img src="img/welcome/processing.gif"
-                                    width="24px" height="24px" /> &zwnj;Applying Changes...&zwnj;</span>
+                        <div class="text-md-right">
+                            <div class="nemoshare-remove">
+                                <span id="nemoshare-remove" class="alert alert-success"> <i
+                                        class="material-icons">&#xE876;</i>&zwnj;Nemo Share is installed&zwnj;</span>
+                                    <a class="btn btn-danger" onclick="cmd('remove?nemoshare');">
+                                            <span class="material-icons">&#xE872;</span><span
+                                                class="button-text">&zwnj;Remove&zwnj;</span>
+                                    </a>
+                                <span id="nemoshare-status" class="hidden"><img src="img/welcome/processing.gif"
+                                        width="24px" height="24px" /> &zwnj;Applying Changes...&zwnj;</span>
+                            </div>
+                            <a id="nemoshare-install" class="btn btn-success hvr-shadow" onclick="cmd('install?nemoshare');"> &nbsp;<span
+                                class="material-icons">&#xE2C0;</span>&zwnj;Install Nemo Share&zwnj;&nbsp;
+                            </a>
                         </div>
-                        <a id="nemoshare-install" class="btn btn-success hvr-shadow" onclick="cmd('install?nemoshare');"> &nbsp;<span
-                            class="material-icons">&#xE2C0;</span>&zwnj;Install Nemo Share&zwnj;&nbsp;
-                        </a>
                         <hr />
                     </div>
                     <div>
@@ -183,18 +187,20 @@
                                 of printer drivers which includes drivers for Epson and Canon printers. Gutenprint supports only the printer part of multi-function devices.&zwnj;</p>
                         </div>
                         <div class="text-md-right">
-                            <span id="gutenprint-remove" class="alert alert-success"> <i class="material-icons">&#xE876;</i>&zwnj;Gutenprint is installed&zwnj;</span>
-                            <a id="gutenprint-install" class="btn btn-success hvr-shadow"
-                                onclick="cmd('install?gutenprint');"> &nbsp;<span
-                                    class="material-icons">&#xE2C0;</span>&zwnj;Install Gutenprint&zwnj;&nbsp;
-                            </a>
-                            <a class="btn btn-danger" onclick="cmd('remove?gutenprint');">
-                                <span class="material-icons">&#xE872;</span><span
+                            <div class="gutenprint-remove">
+                                <span id="gutenprint-remove" class="alert alert-success"> <i class="material-icons">&#xE876;</i>&zwnj;Gutenprint is installed&zwnj;</span>
+                                <a class="btn btn-danger" onclick="cmd('remove?gutenprint');">
+                                    <span class="material-icons">&#xE872;</span><span
                                     class="button-text">&zwnj;Remove&zwnj;</span>
-                            </a>
-                            <span id="gutenprint-status" class="hidden"><img src="img/welcome/processing.gif"
+                                </a>
+                                <span id="gutenprint-status" class="hidden"><img src="img/welcome/processing.gif"
                                     width="24px" height="24px" /> &zwnj;Applying Changes...&zwnj;</span>
-                        </div>
+                            </div>
+                            <a id="gutenprint-install" class="btn btn-success hvr-shadow"
+                            onclick="cmd('install?gutenprint');"> &nbsp;<span
+                            class="material-icons">&#xE2C0;</span>&zwnj;Install Gutenprint&zwnj;&nbsp;
+                            </a>
+                            </div>
                         <hr />
                     </div>
                     <div>

--- a/data/recommendations.html
+++ b/data/recommendations.html
@@ -61,7 +61,7 @@
                                 </small></span>
                             </div>
                             <a id="backup-install" class="btn btn-success" onclick="cmd('install?backup');">&nbsp;<span
-                                class="material-icons">&#xE2C0;</span><span class="button-text">&zwnj;Install&zwnj;</span>&nbsp;</a>
+                                class="material-icons">&#xE2C0;</span><span class="button-text">&zwnj;Install Deja-Dup&zwnj;</span>&nbsp;</a>
                             <span id="backup-status" class="hidden"><img src="img/welcome/processing.gif" width="24px" height="24px" />
                             &zwnj;Applying Changes...&zwnj;</span>
                         </div>
@@ -95,7 +95,7 @@
                                 </small></span>
                             </div>
                             <a id="firewall-install" class="btn btn-success" onclick="cmd('install?firewall');">&nbsp;<span
-                                class="material-icons">&#xE2C0;</span><span class="button-text">&zwnj;Install&zwnj;</span>&nbsp;</a>
+                                class="material-icons">&#xE2C0;</span><span class="button-text">&zwnj;Install Firewall&zwnj;</span>&nbsp;</a>
                             <span id="firewall-status" class="hidden"><img src="img/welcome/processing.gif" width="24px" height="24px" />
                             &zwnj;Applying Changes...&zwnj;</span>
                         </div>

--- a/data/recommendations.html
+++ b/data/recommendations.html
@@ -88,19 +88,19 @@
                         </div>
                         <div class="text-md-right">
                             <div id="firewall-remove">
-                            <a class="btn btn-inverse" onclick="cmd('firewall');">
-                                &nbsp;<img class="button-icon" src="img/applications/gufw.png" />&nbsp;<span
-                                class="button-text">&zwnj;Configure Firewall&zwnj;</span>&nbsp;
-                            </a>
-                            <a class="btn btn-danger" onclick="cmd('remove?firewall');">
-                                <span class="material-icons">&#xE872;</span><span
-                                    class="button-text">&zwnj;Remove&zwnj;</span>
-                            </a>
-                            <span id="firewall-hint" class="center"><small>
-                                <p><i class="material-icons">&#xE88F;</i> <b>&zwnj;Firewall Configuration</b> can be found later in the menu
-                                    <b>System Tools<i class="material-icons">&#xE315;</i> Firewall Configuration</i></b>.&zwnj;
-                                  </p>
-                                </small></span>
+                                <a class="btn btn-inverse" onclick="cmd('firewall');">
+                                    &nbsp;<img class="button-icon" src="img/applications/gufw.png" />&nbsp;<span
+                                    class="button-text">&zwnj;Configure Firewall&zwnj;</span>&nbsp;
+                                </a>
+                                <a class="btn btn-danger" onclick="cmd('remove?firewall');">
+                                    <span class="material-icons">&#xE872;</span><span
+                                        class="button-text">&zwnj;Remove&zwnj;</span>
+                                </a>
+                                <span id="firewall-hint" class="center"><small>
+                                    <p><i class="material-icons">&#xE88F;</i> <b>&zwnj;Firewall Configuration</b> can be found later in the menu
+                                        <b>System Tools<i class="material-icons">&#xE315;</i> Firewall Configuration</i></b>.&zwnj;
+                                    </p>
+                                    </small></span>
                             </div>
                             <a id="firewall-install" class="btn btn-success" onclick="cmd('install?firewall');">&nbsp;<span
                                 class="material-icons">&#xE2C0;</span><span class="button-text">&zwnj;Install Firewall&zwnj;</span>&nbsp;</a>
@@ -119,18 +119,20 @@
                                 light-weight, on-demand scanner for Linux systems.&zwnj;</p>
                         </div>
                         <div class="text-md-right">
-                            <span id="clamav-remove" class="alert alert-success"> 
-                                <i class="material-icons">&#xE876;</i>&zwnj;ClamAV is installed&zwnj;</span>
-                                <a id="clamav-install" class="btn btn-success hvr-shadow" onclick="cmd('install?clamav');"> &nbsp;<span
-                                    class="material-icons">&#xE2C0;</span>&zwnj;Install & Configure
-                                ClamAV&zwnj;&nbsp;
-                                </a>
-                                <a class="btn btn-danger" onclick="cmd('remove?clamav');">
-                                    <span class="material-icons">&#xE872;</span><span
+                            <div id="clamav-remove">
+                                <span id="clamav-remove" class="alert alert-success"> 
+                                    <i class="material-icons">&#xE876;</i>&zwnj;ClamAV is installed&zwnj;</span>
+                                    <a class="btn btn-danger" onclick="cmd('remove?clamav');">
+                                        <span class="material-icons">&#xE872;</span><span
                                         class="button-text">&zwnj;Remove&zwnj;</span>
-                                </a>
-                            <span id="clamav-status" class="hidden"><img src="img/welcome/processing.gif"
-                                    width="24px" height="24px" /> &zwnj;Applying Changes...&zwnj;</span>
+                                    </a>
+                                    <span id="clamav-status" class="hidden"><img src="img/welcome/processing.gif"
+                                        width="24px" height="24px" /> &zwnj;Applying Changes...&zwnj;</span>
+                            </div>
+                            <a id="clamav-install" class="btn btn-success hvr-shadow" onclick="cmd('install?clamav');"> &nbsp;<span
+                                class="material-icons">&#xE2C0;</span>&zwnj;Install & Configure
+                            ClamAV&zwnj;&nbsp;
+                            </a>
                         </div>
                         <hr />
                     </div>
@@ -139,18 +141,18 @@
                         <div class="card card-block">
                             <p>&zwnj;Nemo Preview allows you to quickly view the contents of a highlighted file from the Nemo file manager. Just press space to toggle the preview on and off.&zwnj;</p>
                         </div>
-                        <div class="text-md-right">
+                        <div class="text-md-right nemopreview-remove">
                             <span id="nemopreview-remove" class="alert alert-success"> <i class="material-icons">&#xE876;</i>&zwnj;Nemo Preview is installed&zwnj;</span>
-                            <a id="nemopreview-install" class="btn btn-success hvr-shadow" onclick="cmd('install?nemopreview');"> &nbsp;<span
-                                    class="material-icons">&#xE2C0;</span>&zwnj;Install Nemo Preview&zwnj;&nbsp;
-                            </a>
                             <a class="btn btn-danger" onclick="cmd('remove?nemopreview');">
                                 <span class="material-icons">&#xE872;</span><span
-                                    class="button-text">&zwnj;Remove&zwnj;</span>
+                                class="button-text">&zwnj;Remove&zwnj;</span>
                             </a>
                             <span id="nemopreview-status" class="hidden"><img src="img/welcome/processing.gif"
-                                    width="24px" height="24px" /> &zwnj;Applying Changes...&zwnj;</span>
+                                width="24px" height="24px" /> &zwnj;Applying Changes...&zwnj;</span>
                         </div>
+                        <a id="nemopreview-install" class="btn btn-success hvr-shadow" onclick="cmd('install?nemopreview');"> &nbsp;<span
+                                class="material-icons">&#xE2C0;</span>&zwnj;Install Nemo Preview&zwnj;&nbsp;
+                        </a>
                         <hr />
                     </div>
                     <div>
@@ -159,12 +161,9 @@
                             <p>&zwnj;Nemo Share allows you to quickly share a folder from the Nemo file manager without
                                 requiring root access.&zwnj;</p>
                         </div>
-                        <div class="text-md-right">
+                        <div class="text-md-right nemoshare-remove">
                             <span id="nemoshare-remove" class="alert alert-success"> <i
                                     class="material-icons">&#xE876;</i>&zwnj;Nemo Share is installed&zwnj;</span>
-                                <a id="nemoshare-install" class="btn btn-success hvr-shadow" onclick="cmd('install?nemoshare');"> &nbsp;<span
-                                    class="material-icons">&#xE2C0;</span>&zwnj;Install Nemo Share&zwnj;&nbsp;
-                                </a>
                                 <a class="btn btn-danger" onclick="cmd('remove?nemoshare');">
                                         <span class="material-icons">&#xE872;</span><span
                                             class="button-text">&zwnj;Remove&zwnj;</span>
@@ -172,6 +171,9 @@
                             <span id="nemoshare-status" class="hidden"><img src="img/welcome/processing.gif"
                                     width="24px" height="24px" /> &zwnj;Applying Changes...&zwnj;</span>
                         </div>
+                        <a id="nemoshare-install" class="btn btn-success hvr-shadow" onclick="cmd('install?nemoshare');"> &nbsp;<span
+                            class="material-icons">&#xE2C0;</span>&zwnj;Install Nemo Share&zwnj;&nbsp;
+                        </a>
                         <hr />
                     </div>
                     <div>

--- a/data/recommendations.html
+++ b/data/recommendations.html
@@ -142,18 +142,16 @@
                             <p>&zwnj;Nemo Preview allows you to quickly view the contents of a highlighted file from the Nemo file manager. Just press space to toggle the preview on and off.&zwnj;</p>
                         </div>
                         <div class="text-md-right">
-                            <div class="nemopreview-remove">
-                                <span id="nemopreview-remove" class="alert alert-success"> <i class="material-icons">&#xE876;</i>&zwnj;Nemo Preview is installed&zwnj;</span>
-                                <a class="btn btn-danger" onclick="cmd('remove?nemopreview');">
-                                    <span class="material-icons">&#xE872;</span><span
-                                    class="button-text">&zwnj;Remove&zwnj;</span>
-                                </a>
-                                <span id="nemopreview-status" class="hidden"><img src="img/welcome/processing.gif"
-                                    width="24px" height="24px" /> &zwnj;Applying Changes...&zwnj;</span>
-                            </div>
+                            <span id="nemopreview-remove" class="alert alert-success"> <i class="material-icons">&#xE876;</i>&zwnj;Nemo Preview is installed&zwnj;</span>
                             <a id="nemopreview-install" class="btn btn-success hvr-shadow" onclick="cmd('install?nemopreview');"> &nbsp;<span
                                     class="material-icons">&#xE2C0;</span>&zwnj;Install Nemo Preview&zwnj;&nbsp;
                             </a>
+                            <a class="btn btn-danger" onclick="cmd('remove?nemopreview');">
+                                <span class="material-icons">&#xE872;</span><span
+                                    class="button-text">&zwnj;Remove&zwnj;</span>
+                            </a>
+                            <span id="nemopreview-status" class="hidden"><img src="img/welcome/processing.gif"
+                                    width="24px" height="24px" /> &zwnj;Applying Changes...&zwnj;</span>
                         </div>
                         <hr />
                     </div>
@@ -164,19 +162,17 @@
                                 requiring root access.&zwnj;</p>
                         </div>
                         <div class="text-md-right">
-                            <div class="nemoshare-remove">
-                                <span id="nemoshare-remove" class="alert alert-success"> <i
-                                        class="material-icons">&#xE876;</i>&zwnj;Nemo Share is installed&zwnj;</span>
-                                    <a class="btn btn-danger" onclick="cmd('remove?nemoshare');">
-                                            <span class="material-icons">&#xE872;</span><span
-                                                class="button-text">&zwnj;Remove&zwnj;</span>
-                                    </a>
-                                <span id="nemoshare-status" class="hidden"><img src="img/welcome/processing.gif"
-                                        width="24px" height="24px" /> &zwnj;Applying Changes...&zwnj;</span>
-                            </div>
-                            <a id="nemoshare-install" class="btn btn-success hvr-shadow" onclick="cmd('install?nemoshare');"> &nbsp;<span
-                                class="material-icons">&#xE2C0;</span>&zwnj;Install Nemo Share&zwnj;&nbsp;
-                            </a>
+                            <span id="nemoshare-remove" class="alert alert-success"> <i
+                                    class="material-icons">&#xE876;</i>&zwnj;Nemo Share is installed&zwnj;</span>
+                                <a id="nemoshare-install" class="btn btn-success hvr-shadow" onclick="cmd('install?nemoshare');"> &nbsp;<span
+                                    class="material-icons">&#xE2C0;</span>&zwnj;Install Nemo Share&zwnj;&nbsp;
+                                </a>
+                                <a class="btn btn-danger" onclick="cmd('remove?nemoshare');">
+                                        <span class="material-icons">&#xE872;</span><span
+                                            class="button-text">&zwnj;Remove&zwnj;</span>
+                                </a>
+                            <span id="nemoshare-status" class="hidden"><img src="img/welcome/processing.gif"
+                                    width="24px" height="24px" /> &zwnj;Applying Changes...&zwnj;</span>
                         </div>
                         <hr />
                     </div>
@@ -187,20 +183,18 @@
                                 of printer drivers which includes drivers for Epson and Canon printers. Gutenprint supports only the printer part of multi-function devices.&zwnj;</p>
                         </div>
                         <div class="text-md-right">
-                            <div class="gutenprint-remove">
-                                <span id="gutenprint-remove" class="alert alert-success"> <i class="material-icons">&#xE876;</i>&zwnj;Gutenprint is installed&zwnj;</span>
-                                <a class="btn btn-danger" onclick="cmd('remove?gutenprint');">
-                                    <span class="material-icons">&#xE872;</span><span
-                                    class="button-text">&zwnj;Remove&zwnj;</span>
-                                </a>
-                                <span id="gutenprint-status" class="hidden"><img src="img/welcome/processing.gif"
-                                    width="24px" height="24px" /> &zwnj;Applying Changes...&zwnj;</span>
-                            </div>
+                            <span id="gutenprint-remove" class="alert alert-success"> <i class="material-icons">&#xE876;</i>&zwnj;Gutenprint is installed&zwnj;</span>
                             <a id="gutenprint-install" class="btn btn-success hvr-shadow"
-                            onclick="cmd('install?gutenprint');"> &nbsp;<span
-                            class="material-icons">&#xE2C0;</span>&zwnj;Install Gutenprint&zwnj;&nbsp;
+                                onclick="cmd('install?gutenprint');"> &nbsp;<span
+                                    class="material-icons">&#xE2C0;</span>&zwnj;Install Gutenprint&zwnj;&nbsp;
                             </a>
-                            </div>
+                            <a class="btn btn-danger" onclick="cmd('remove?gutenprint');">
+                                <span class="material-icons">&#xE872;</span><span
+                                    class="button-text">&zwnj;Remove&zwnj;</span>
+                            </a>
+                            <span id="gutenprint-status" class="hidden"><img src="img/welcome/processing.gif"
+                                    width="24px" height="24px" /> &zwnj;Applying Changes...&zwnj;</span>
+                        </div>
                         <hr />
                     </div>
                     <div>

--- a/data/recommendations.html
+++ b/data/recommendations.html
@@ -59,6 +59,10 @@
                                     <b>Utilities <i class="material-icons">&#xE315;</i> Backups</b>.&zwnj;
                                 </p>
                                 </small></span>
+                            <a class="btn btn-danger" onclick="cmd('remove?backup');">
+                                <span class="material-icons">&#xE872;</span><span
+                                    class="button-text">&zwnj;Remove&zwnj;</span>
+                            </a>
                             </div>
                             <a id="backup-install" class="btn btn-success" onclick="cmd('install?backup');">&nbsp;<span
                                 class="material-icons">&#xE2C0;</span><span class="button-text">&zwnj;Install Deja-Dup&zwnj;</span>&nbsp;</a>

--- a/data/recommendations.html
+++ b/data/recommendations.html
@@ -34,7 +34,7 @@
                         </div>
                     </div>
                     
-                    <div class="col-md-6">
+                    <div>
                         <h2>&zwnj;Backups&zwnj;</h2>
                         <div class="card card-block">
                             <div class="card-image text-md-center">
@@ -68,7 +68,7 @@
                         <hr>
                     </div>
               
-                    <div class="col-md-6">
+                    <div>
                         <h2>&zwnj;Firewall&zwnj;</h2>
                         <div class="card card-block">
                             <div class="card-image text-md-center">

--- a/data/recommendations.html
+++ b/data/recommendations.html
@@ -161,7 +161,7 @@
                         </div>
                         <div class="text-md-right">
                             <span id="nemoshare-remove" class="alert alert-success"> <i
-                                    class="material-icons">&#xE876;</i>&zwnj;Nemo Share is installed&zwnj;</span>\
+                                    class="material-icons">&#xE876;</i>&zwnj;Nemo Share is installed&zwnj;</span>
                                 <a id="nemoshare-install" class="btn btn-success hvr-shadow" onclick="cmd('install?nemoshare');"> &nbsp;<span
                                     class="material-icons">&#xE2C0;</span>&zwnj;Install Nemo Share&zwnj;&nbsp;
                                 </a>


### PR DESCRIPTION
This PR is a follow-up to changes on the getting started page.
- Make the screenshot for Dropbox smaller
- Fixed bug where Dropbox install button was not visible
- The alert for install of Flatpak was text-wrapped. (Converted the span to a div)

After merging changes, please also update Mauro.