### PR TITLE
Fix layout of dropbox image & flatpak post install instructions

### DIFF
--- a/data/gettingstarted.html
+++ b/data/gettingstarted.html
@@ -793,8 +793,8 @@
               &zwnj;Applying Changes...&zwnj;</span>
             <a id="flatpak-install" class="btn btn-success" onclick="cmd('install?flatpak');">&nbsp;<span 
               class="material-icons">&#xE2C0;</span><span class="button-text">&zwnj;Install & Configure Flatpak&zwnj;</span>&nbsp;</a>
-            <span id="flatpak-remove" class="alert alert-success"> <i class="material-icons">&#xE876;</i>&zwnj;Flatpak is installed. 
-              Please reboot for the service to start&zwnj;</span>
+            <div id="flatpak-remove" class="alert alert-success"> <i class="material-icons">&#xE876;</i>&zwnj;Flatpak is installed.&zwnj;</div>
+            <p id="flatpak-instruction" class="hidden"><small>&zwnj;Please reboot for the service to start.&zwnj;</small></p>
             <span id="flatpak-hint" class="center"><small>
                 <p>&zwnj;Being a user friendly distribution, Ubuntu Budgie allows you to install Flatpak with a single click. 
                   After setup, you can use <strong>Software</strong> to install Flatpak applications.&zwnj;

--- a/data/gettingstarted.html
+++ b/data/gettingstarted.html
@@ -806,7 +806,7 @@
         
         <div class="row wow fadeIn">
           <div class="col-md-6 center-inside">
-            <img src="img/logos/dropbox.png" style="width: 100%">
+            <img src="img/logos/dropbox.png">
           </div>
           <div class="col-md-6">
             <h3>&zwnj;Dropbox&zwnj;</h3>


### PR DESCRIPTION
This PR is a follow-up to changes on the getting started page. 
It's a resolution to the issues in PR #307 

- Make the screenshot for Dropbox smaller
- The alert for install of Flatpak was text-wrapped. (Converted the span to a div)

After merging changes, please also update Mauro.