### PR TITLE
Update packages.json to include nemo dropbox

### DIFF
--- a/data/config/packages.json
+++ b/data/config/packages.json
@@ -1318,13 +1318,25 @@
 		"flatpak-setup": {
 			"script": "flatpak-remote"
 		},
-		"dropbox": {
+		"nemodropbox": {
 			"packages": [
-				"nautilus-dropbox"
+				"nemo-dropbox"
 			],
 			"repos": {
-				"all": [
-					"multiverse"
+				"focal": [
+					"ppa:ubuntubudgie/backports"
+				],
+				"jammy": [
+					"ppa:ubuntubudgie/backports"
+				],
+				"kinetic": [
+					"ppa:ubuntubudgie/backports"
+				],
+				"lunar": [
+					"ppa:ubuntubudgie/backports"
+				],
+				"mantic": [
+					"ppa:ubuntubudgie/backports"
 				]
 			}
 		},


### PR DESCRIPTION
The package.json was mistakingly having dropbox (nautilius) in the geeting started section whereas nemo-dropbox is expected.
Edited the package file to use nemo dropbox.

This caused the install button to not show up.
As always, after merge and build, please update Mauro.

Thanks