### PR TITLE
i386 dependencies

### DIFF
--- a/data/config/packages.json
+++ b/data/config/packages.json
@@ -1644,7 +1644,10 @@
 				"all": [
 					"multiverse"
 				]
-			}
+			},
+			"key-commands": [
+				"sudo dpkg --add-architecture i386"
+			]
 		},
 		"steam": {
 			"packages": [


### PR DESCRIPTION
Have the Lutris installation add i386 dependencies to the system, they are necessary for Lutris to work.