### PR TITLE
Add "sudo apt update" for Lutris installation.

### DIFF
--- a/data/config/packages.json
+++ b/data/config/packages.json
@@ -1646,7 +1646,8 @@
 				]
 			},
 			"key-commands": [
-				"sudo dpkg --add-architecture i386"
+				"sudo dpkg --add-architecture i386",
+				"sudo apt update"
 			]
 		},
 		"steam": {


### PR DESCRIPTION
Unlike Steam, Lutris requires a "sudo apt update" to be run before being installed, so that APT can recognize that i386 packages are available.