### PR TITLE
Update Online Store link to current Zazzle site.

### DIFF
--- a/data/store.html
+++ b/data/store.html
@@ -28,7 +28,7 @@
             &zwnj;Please note that the button below will take you to an external site for browsing and purchasing.&zwnj;
           </div>
           <div align="center">
-            <a class="btn btn-inverse" onclick="cmd('link?https://ubuntubudgie.org/merch');">
+            <a class="btn btn-inverse" onclick="cmd('link?https://www.zazzle.com.au/store/ubuntubudgie');">
               <img class="button-icon" src="img/distro-icon-inverted.svg">&nbsp;<span class="button-text">Ubuntu Budgie &zwnj;Online Store&zwnj;</span>
             </a>
           </div>

--- a/data/stripped/en_US/store.html
+++ b/data/stripped/en_US/store.html
@@ -28,7 +28,7 @@
             Please note that the button below will take you to an external site for browsing and purchasing.
           </div>
           <div align="center">
-            <a class="btn btn-inverse" onclick="cmd('link?https://ubuntubudgie.org/merch');">
+            <a class="btn btn-inverse" onclick="cmd('link?https://www.zazzle.com.au/store/ubuntubudgie');">
               <img class="button-icon" src="../../img/distro-icon-inverted.svg">&nbsp;<span class="button-text">Ubuntu Budgie Online Store</span>
             </a>
           </div>


### PR DESCRIPTION
Update the link of the "Ubuntu Budgie Online Store" button under "Online Store".

Current link is https://ubuntubudgie.org/merch and is a 404 as there is no /merch under the https://github.com/UbuntuBudgie/Website/tree/main/src/pages
